### PR TITLE
Add pytest for debug endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,24 @@ This is a Flask web app that connects to a local [Ollama](https://ollama.com) LL
 ```bash
 git clone https://github.com/braydos-h/IGOON.ORG-AI
 cd multi-persona-chat
+```
+
+### 2. Install Dependencies
+
+```bash
+pip install flask psutil pytest
+```
+
+### 3. Run the App
+
+```bash
+python app.py
+```
+
+## Running Tests
+
+Use `pytest` to run the test suite:
+
+```bash
+pytest
+```

--- a/tests/test_debug_endpoint.py
+++ b/tests/test_debug_endpoint.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app import app
+
+
+def test_debug_endpoint():
+    with app.test_client() as client:
+        response = client.get('/debug')
+        assert response.status_code == 200
+        data = response.get_json()
+        assert 'cpu_usage' in data
+        assert 'ram_usage' in data


### PR DESCRIPTION
## Summary
- add `tests/` with coverage for `/debug`
- document dependency installation and how to run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f8ebdcad0832590c084f8dbf4b994