### PR TITLE
Add generate endpoint test and expand debug tests

### DIFF
--- a/tests/test_debug_endpoint.py
+++ b/tests/test_debug_endpoint.py
@@ -12,3 +12,6 @@ def test_debug_endpoint():
         data = response.get_json()
         assert 'cpu_usage' in data
         assert 'ram_usage' in data
+        assert 'disk_usage' in data
+        assert 'ping' in data
+        assert 'wifi' in data

--- a/tests/test_generate_endpoint.py
+++ b/tests/test_generate_endpoint.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import io
+from unittest.mock import patch
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app import app
+
+
+class DummyProcess:
+    """A minimal stand-in for subprocess.Popen used in testing."""
+
+    def __init__(self, output: str):
+        self.stdout = io.StringIO(output)
+
+    def wait(self):
+        return 0
+
+
+def test_generate_endpoint():
+    dummy_text = "generated line\n"
+    with patch("subprocess.Popen", return_value=DummyProcess(dummy_text)) as mock_popen:
+        with app.test_client() as client:
+            response = client.post("/generate", json={"prompt": "hi"})
+
+            assert response.status_code == 200
+            assert dummy_text.strip() in response.get_data(as_text=True)
+
+        mock_popen.assert_called_once()
+        args = mock_popen.call_args[0][0]
+        assert args[:3] == ["ollama", "run", "qwen2.5:1.5b"]
+


### PR DESCRIPTION
## Summary
- enhance debug endpoint test with more key checks
- add new tests for the /generate endpoint using a mocked subprocess

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f92cf26f08325aaa6a36b77873938