### PR TITLE
Add flake8 config and lint instructions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: lint test
+
+lint:
+	flake8
+
+test:
+	pytest
+

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cd multi-persona-chat
 ### 2. Install Dependencies
 
 ```bash
-pip install flask psutil pytest
+pip install flask psutil pytest flake8
 ```
 
 ### 3. Run the App
@@ -54,4 +54,18 @@ Use `pytest` to run the test suite:
 
 ```bash
 pytest
+```
+
+## Linting
+
+Run [Flake8](https://flake8.pycqa.org/) to check code style:
+
+```bash
+flake8
+```
+
+Alternatively, use the `make lint` command if you have `make` installed:
+
+```bash
+make lint
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 psutil
 pytest
+flake8


### PR DESCRIPTION
## Summary
- set up a simple `.flake8` configuration
- add `make lint` helper and mention `make test`
- document how to run flake8 in the README
- include flake8 in requirements

## Testing
- `flake8` *(fails: E501, E122, etc.)*
- `make lint` *(fails: E501, E122, etc.)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683f92d1bd748325919cea681f53b32b